### PR TITLE
Change .bash_profile to .bashrc for Linux

### DIFF
--- a/InstallMediaPipe.sh
+++ b/InstallMediaPipe.sh
@@ -76,7 +76,7 @@ if [ $conda_is_already_installed = 0 ]; then
 		source ~/.bash_profile
 	elif [[ "$OSTYPE" =~ ^linux ]]; then
 		# reinit bash profile
-		source ~/.bash_profile
+		source ~/.bashrc
 	fi
 
 fi


### PR DESCRIPTION
Hi and thank you for this fantastic add-on. I just made a tiny change to specify the correct shell config path for linux users. Working really well in Ubuntu 24.